### PR TITLE
Thin dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ requires = ["setuptools", "wheel"]
 
 [project]
 name = "PTJPL"
-version = "1.5.1"
+version = "1.5.2"
 description = "Priestley-Taylor Jet Propulsion Laboratory Evapotranspiration Model"
 readme = "README.md"
 authors = [
@@ -18,15 +18,10 @@ classifiers = [
 dependencies = [
     "carlson-leaf-area-index",
     "colored-logging",
-    "ECOv002-CMR>=1.0.5",
-    "ECOv002-granules>=1.0.3",
-    "ECOv003-granules",
     "GEOS5FP>=1.2.2",
-    "monte-carlo-sensitivity",
     "numpy",
     "pandas",
     "rasters>=1.7.1",
-    "seaborn",
     "SEBAL-soil-heat-flux",
     "solar-apparent-time",
     "verma-net-radiation>=1.2.1"
@@ -41,6 +36,14 @@ dev = [
     "jupyter",
     "pytest",
     "twine"
+]
+
+[dependency-groups]
+sensitivity = [
+    "ECOv002-CMR>=1.0.5",
+    "ECOv002-granules>=1.0.3",
+    "monte-carlo-sensitivity",
+    "seaborn",
 ]
 
 [tool.setuptools.packages.find]


### PR DESCRIPTION
Make the library more lightweight to install, by removing dependencies which aren't used at all, and moving sensitivity-specific dependencies to a dependency group.

Closes #36 